### PR TITLE
Add trading bot with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1826,6 +1826,18 @@ Feel free to contact me to discuss any issues, questions, or comments.
 
 My contact info can be found on my [GitHub page](https://github.com/donnemartin).
 
+## Running the trading bot tests
+
+To run the unit tests for the trading bot:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install requests pytest
+pytest
+```
+
+
 ## License
 
 *I am providing code and resources in this repository to you under an open source license.  Because this is my personal repository, the license you receive to my code and resources is from me and not my employer (Facebook).*

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,44 @@
+import pytest
+from trading_bot.bot import TradingBot
+from requests.exceptions import HTTPError, Timeout
+
+class DummyResponse:
+    def __init__(self, json_data=None, status_code=200):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise HTTPError(f"{self.status_code} error")
+
+    def json(self):
+        return self._json_data
+
+def test_get_price_success(monkeypatch):
+    bot = TradingBot("http://example.com")
+
+    def mock_get(url, timeout):
+        return DummyResponse({"price": 100.0})
+
+    monkeypatch.setattr("trading_bot.bot.requests.get", mock_get)
+    assert bot.get_price("BTC") == 100.0
+
+def test_get_price_http_error(monkeypatch):
+    bot = TradingBot("http://example.com")
+
+    def mock_get(url, timeout):
+        return DummyResponse(status_code=500)
+
+    monkeypatch.setattr("trading_bot.bot.requests.get", mock_get)
+    with pytest.raises(RuntimeError):
+        bot.get_price("BTC")
+
+def test_get_price_timeout(monkeypatch):
+    bot = TradingBot("http://example.com")
+
+    def mock_get(url, timeout):
+        raise Timeout("timeout")
+
+    monkeypatch.setattr("trading_bot.bot.requests.get", mock_get)
+    with pytest.raises(RuntimeError):
+        bot.get_price("BTC")

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -1,0 +1,27 @@
+import requests
+from requests.exceptions import HTTPError, Timeout, RequestException
+
+class TradingBot:
+    def __init__(self, base_url: str, timeout: int = 5):
+        self.base_url = base_url.rstrip('/')
+        self.timeout = timeout
+
+    def get_price(self, symbol: str) -> float:
+        """Fetch the latest price for a symbol.
+
+        Raises:
+            RuntimeError: If the request fails or times out.
+        """
+        url = f"{self.base_url}/price/{symbol}"
+        try:
+            resp = requests.get(url, timeout=self.timeout)
+            resp.raise_for_status()
+        except Timeout:
+            raise RuntimeError(f"Request timed out when fetching {symbol}")
+        except HTTPError as exc:
+            raise RuntimeError(f"HTTP error when fetching {symbol}: {exc}")
+        except RequestException as exc:
+            raise RuntimeError(f"Request error when fetching {symbol}: {exc}")
+
+        data = resp.json()
+        return float(data.get("price"))


### PR DESCRIPTION
## Summary
- add basic trading bot module
- handle HTTP errors and timeouts gracefully
- add unit tests using pytest
- document how to run tests in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810062d2808323842176afc519d17e