### PR TITLE
Add simple trading bot prototype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ccxt
+flask
+pandas
+matplotlib
+psutil

--- a/trading_bot/README.md
+++ b/trading_bot/README.md
@@ -1,0 +1,34 @@
+# Trading Bot
+
+This folder contains a small experimental trading bot using `ccxt`.  It can
+run in simulation mode or connect directly to an exchange.  Strategies are
+loaded dynamically and evaluated periodically.  A small Flask dashboard shows
+open positions, recent trades and a cumulative P/L chart.
+
+## Setup
+
+Install dependencies in a virtual environment:
+
+```bash
+pip install -r ../requirements.txt
+```
+
+## Usage
+
+Run the bot with the default configuration:
+
+```bash
+python -m trading_bot.run_bot
+```
+
+Key options include:
+
+- `--pairs` to specify a comma separated list of trading pairs
+- `--strategies` to choose which strategies to load
+- `--simulate` to disable real order placement
+- `--refresh-interval` seconds between evaluations
+
+The dashboard will start on the configured port (default `5000`).
+
+Environment variables can also configure the bot.  See `config.py` for the
+full list.

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -1,0 +1,1 @@
+"""Trading bot package."""

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -1,1 +1,5 @@
 """Trading bot package."""
+
+from .bot import TradingBot
+
+__all__ = ["TradingBot"]

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -29,6 +29,7 @@ class TradingBot:
     exchange_id: str = config.EXCHANGE_ID
     strategies: List[Strategy] = field(default_factory=list)
     positions: List[Position] = field(default_factory=list)
+    closed_profit: float = 0.0
     data_path: str = config.DATA_PATH
 
     def __post_init__(self):
@@ -76,6 +77,12 @@ class TradingBot:
 
     def evaluate(self):
         """Evaluate strategies and manage positions."""
+        current_price = None
+        try:
+            current_price = self.exchange.fetch_ticker(config.TRADING_PAIR)["last"]
+        except Exception as exc:
+            logger.warning("Failed to fetch ticker: %s", exc)
+
         entry_votes = []
         exit_votes = []
         for strat in self.strategies:
@@ -87,17 +94,32 @@ class TradingBot:
             except Exception:
                 logger.exception("Error in strategy %s", strat.__class__.__name__)
 
-        if not self.positions and len(entry_votes) >= config.ENTRY_THRESHOLD:
-            price = entry_votes[0].data["close"].iloc[-1]
+        if not self.positions and len(entry_votes) >= config.ENTRY_THRESHOLD and current_price is not None:
+            price = current_price
             if self.place_order("buy", config.ORDER_SIZE):
                 self.positions.append(Position(price, config.ORDER_SIZE, "combined"))
                 self.record_trade("enter", price, config.ORDER_SIZE, "combined")
                 logger.info("Entered position at %s based on %d strategies", price, len(entry_votes))
 
-        elif self.positions and len(exit_votes) >= config.EXIT_THRESHOLD:
+        elif self.positions:
             pos = self.positions[0]
-            if self.place_order("sell", pos.amount):
-                logger.info("Exiting position opened at %s", pos.entry_price)
-                self.record_trade("exit", pos.entry_price, pos.amount, "combined")
-                self.positions.clear()
+            risk_exit = False
+            if current_price is not None:
+                change_pct = (current_price - pos.entry_price) / pos.entry_price * 100
+                if config.TAKE_PROFIT_PCT and change_pct >= config.TAKE_PROFIT_PCT:
+                    logger.info("Take profit reached: %.2f%%", change_pct)
+                    risk_exit = True
+                elif config.STOP_LOSS_PCT and change_pct <= -config.STOP_LOSS_PCT:
+                    logger.info("Stop loss reached: %.2f%%", change_pct)
+                    risk_exit = True
+
+            if len(exit_votes) >= config.EXIT_THRESHOLD or risk_exit:
+                if current_price is None:
+                    current_price = pos.entry_price
+                if self.place_order("sell", pos.amount):
+                    pnl = (current_price - pos.entry_price) * pos.amount
+                    self.closed_profit += pnl
+                    logger.info("Exiting position opened at %s with P/L %.2f", pos.entry_price, pnl)
+                    self.record_trade("exit", current_price, pos.amount, "combined")
+                    self.positions.clear()
 

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -16,10 +16,11 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class Position:
-    """Simple representation of an open position."""
+    """Representation of an open position."""
     entry_price: float
     amount: float
     strategy: str
+    timestamp: float = field(default_factory=time.time)
 
 @dataclass
 class TradingBot:
@@ -60,23 +61,43 @@ class TradingBot:
             self.strategies.append(strategy)
         logger.info("Loaded strategies: %s", [s.__class__.__name__ for s in self.strategies])
 
+    def place_order(self, side: str, amount: float) -> Any:
+        """Execute an order on the exchange or simulate it."""
+        if config.SIMULATE:
+            logger.info("Simulated %s order for %s %s", side, amount, config.TRADING_PAIR)
+            return {"simulated": True}
+        try:
+            if side == "buy":
+                return self.exchange.create_market_buy_order(config.TRADING_PAIR, amount)
+            return self.exchange.create_market_sell_order(config.TRADING_PAIR, amount)
+        except Exception as exc:
+            logger.warning("Failed to place %s order: %s", side, exc)
+            return None
+
     def evaluate(self):
         """Evaluate strategies and manage positions."""
+        entry_votes = []
+        exit_votes = []
         for strat in self.strategies:
             try:
                 if strat.should_enter():
-                    price = strat.data["close"].iloc[-1]
-                    amount = 1  # fixed size for example
-                    self.positions.append(Position(price, amount, strat.__class__.__name__))
-                    self.record_trade("enter", price, amount, strat.__class__.__name__)
-                    logger.info("Entered position at %s by %s", price, strat.__class__.__name__)
-            except Exception as exc:
+                    entry_votes.append(strat)
+                if self.positions and strat.should_exit(self.positions[0]):
+                    exit_votes.append(strat)
+            except Exception:
                 logger.exception("Error in strategy %s", strat.__class__.__name__)
 
-        for pos in list(self.positions):
-            strat = next((s for s in self.strategies if s.__class__.__name__ == pos.strategy), None)
-            if strat and strat.should_exit(pos):
-                logger.info("Exiting position from %s at %s", pos.strategy, pos.entry_price)
-                self.record_trade("exit", pos.entry_price, pos.amount, pos.strategy)
-                self.positions.remove(pos)
+        if not self.positions and len(entry_votes) >= config.ENTRY_THRESHOLD:
+            price = entry_votes[0].data["close"].iloc[-1]
+            if self.place_order("buy", config.ORDER_SIZE):
+                self.positions.append(Position(price, config.ORDER_SIZE, "combined"))
+                self.record_trade("enter", price, config.ORDER_SIZE, "combined")
+                logger.info("Entered position at %s based on %d strategies", price, len(entry_votes))
+
+        elif self.positions and len(exit_votes) >= config.EXIT_THRESHOLD:
+            pos = self.positions[0]
+            if self.place_order("sell", pos.amount):
+                logger.info("Exiting position opened at %s", pos.entry_price)
+                self.record_trade("exit", pos.entry_price, pos.amount, "combined")
+                self.positions.clear()
 

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -1,0 +1,55 @@
+import importlib
+import logging
+from dataclasses import dataclass, field
+from typing import List, Any
+
+import ccxt
+
+from . import config
+from .strategy import Strategy
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@dataclass
+class Position:
+    """Simple representation of an open position."""
+    entry_price: float
+    amount: float
+    strategy: str
+
+@dataclass
+class TradingBot:
+    exchange_id: str = "binance"
+    strategies: List[Strategy] = field(default_factory=list)
+    positions: List[Position] = field(default_factory=list)
+
+    def __post_init__(self):
+        self.exchange = getattr(ccxt, self.exchange_id)({
+            "apiKey": config.EXCHANGE_API_KEY,
+            "secret": config.EXCHANGE_SECRET,
+        })
+        self.load_strategies()
+
+    def load_strategies(self):
+        """Dynamically load strategies from config."""
+        for name in config.STRATEGIES:
+            module = importlib.import_module("trading_bot.strategy")
+            cls = getattr(module, name)
+            strategy = cls(self.exchange, config.TRADING_PAIR, config.TIMEFRAME)
+            self.strategies.append(strategy)
+        logger.info("Loaded strategies: %s", [s.__class__.__name__ for s in self.strategies])
+
+    def evaluate(self):
+        """Evaluate strategies and manage positions."""
+        for strat in self.strategies:
+            if strat.should_enter():
+                price = strat.data["close"].iloc[-1]
+                amount = 1  # fixed size for example
+                self.positions.append(Position(price, amount, strat.__class__.__name__))
+                logger.info("Entered position at %s by %s", price, strat.__class__.__name__)
+            for pos in list(self.positions):
+                if pos.strategy == strat.__class__.__name__ and strat.should_exit(pos):
+                    logger.info("Exiting position from %s at %s", pos.strategy, pos.entry_price)
+                    self.positions.remove(pos)
+

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -2,13 +2,16 @@ import importlib
 import logging
 from dataclasses import dataclass, field
 from typing import List, Any
+import csv
+import os
+import time
 
 import ccxt
 
 from . import config
 from .strategy import Strategy
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=getattr(logging, config.LOG_LEVEL))
 logger = logging.getLogger(__name__)
 
 @dataclass
@@ -20,16 +23,33 @@ class Position:
 
 @dataclass
 class TradingBot:
-    exchange_id: str = "binance"
+    """Core trading bot class."""
+
+    exchange_id: str = config.EXCHANGE_ID
     strategies: List[Strategy] = field(default_factory=list)
     positions: List[Position] = field(default_factory=list)
+    data_path: str = config.DATA_PATH
 
     def __post_init__(self):
         self.exchange = getattr(ccxt, self.exchange_id)({
             "apiKey": config.EXCHANGE_API_KEY,
             "secret": config.EXCHANGE_SECRET,
+            "enableRateLimit": True,
         })
         self.load_strategies()
+        # Ensure trade file exists
+        if self.data_path and not os.path.exists(self.data_path):
+            with open(self.data_path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["timestamp", "action", "price", "amount", "strategy"])
+
+    def record_trade(self, action: str, price: float, amount: float, strategy: str) -> None:
+        """Persist trade information to CSV."""
+        if not self.data_path:
+            return
+        with open(self.data_path, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([int(time.time()), action, price, amount, strategy])
 
     def load_strategies(self):
         """Dynamically load strategies from config."""
@@ -43,13 +63,20 @@ class TradingBot:
     def evaluate(self):
         """Evaluate strategies and manage positions."""
         for strat in self.strategies:
-            if strat.should_enter():
-                price = strat.data["close"].iloc[-1]
-                amount = 1  # fixed size for example
-                self.positions.append(Position(price, amount, strat.__class__.__name__))
-                logger.info("Entered position at %s by %s", price, strat.__class__.__name__)
-            for pos in list(self.positions):
-                if pos.strategy == strat.__class__.__name__ and strat.should_exit(pos):
-                    logger.info("Exiting position from %s at %s", pos.strategy, pos.entry_price)
-                    self.positions.remove(pos)
+            try:
+                if strat.should_enter():
+                    price = strat.data["close"].iloc[-1]
+                    amount = 1  # fixed size for example
+                    self.positions.append(Position(price, amount, strat.__class__.__name__))
+                    self.record_trade("enter", price, amount, strat.__class__.__name__)
+                    logger.info("Entered position at %s by %s", price, strat.__class__.__name__)
+            except Exception as exc:
+                logger.exception("Error in strategy %s", strat.__class__.__name__)
+
+        for pos in list(self.positions):
+            strat = next((s for s in self.strategies if s.__class__.__name__ == pos.strategy), None)
+            if strat and strat.should_exit(pos):
+                logger.info("Exiting position from %s at %s", pos.strategy, pos.entry_price)
+                self.record_trade("exit", pos.entry_price, pos.amount, pos.strategy)
+                self.positions.remove(pos)
 

--- a/trading_bot/bot.py
+++ b/trading_bot/bot.py
@@ -7,6 +7,7 @@ import os
 import time
 
 import ccxt
+import psutil
 
 from . import config
 from .strategy import Strategy
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class Position:
     """Representation of an open position."""
+    pair: str
     entry_price: float
     amount: float
     strategy: str
@@ -43,83 +45,87 @@ class TradingBot:
         if self.data_path and not os.path.exists(self.data_path):
             with open(self.data_path, "w", newline="") as f:
                 writer = csv.writer(f)
-                writer.writerow(["timestamp", "action", "price", "amount", "strategy"])
+                writer.writerow(["timestamp", "pair", "action", "price", "amount", "strategy"])
 
-    def record_trade(self, action: str, price: float, amount: float, strategy: str) -> None:
+    def record_trade(self, pair: str, action: str, price: float, amount: float, strategy: str) -> None:
         """Persist trade information to CSV."""
         if not self.data_path:
             return
         with open(self.data_path, "a", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow([int(time.time()), action, price, amount, strategy])
+            writer.writerow([int(time.time()), pair, action, price, amount, strategy])
 
     def load_strategies(self):
         """Dynamically load strategies from config."""
-        for name in config.STRATEGIES:
-            module = importlib.import_module("trading_bot.strategy")
-            cls = getattr(module, name)
-            strategy = cls(self.exchange, config.TRADING_PAIR, config.TIMEFRAME)
-            self.strategies.append(strategy)
+        for pair in config.TRADING_PAIRS:
+            for name in config.STRATEGIES:
+                module = importlib.import_module("trading_bot.strategy")
+                cls = getattr(module, name)
+                strategy = cls(self.exchange, pair, config.TIMEFRAME)
+                self.strategies.append(strategy)
         logger.info("Loaded strategies: %s", [s.__class__.__name__ for s in self.strategies])
 
-    def place_order(self, side: str, amount: float) -> Any:
+    def place_order(self, side: str, pair: str, amount: float) -> Any:
         """Execute an order on the exchange or simulate it."""
         if config.SIMULATE:
-            logger.info("Simulated %s order for %s %s", side, amount, config.TRADING_PAIR)
+            logger.info("Simulated %s order for %s %s", side, amount, pair)
             return {"simulated": True}
         try:
             if side == "buy":
-                return self.exchange.create_market_buy_order(config.TRADING_PAIR, amount)
-            return self.exchange.create_market_sell_order(config.TRADING_PAIR, amount)
+                return self.exchange.create_market_buy_order(pair, amount)
+            return self.exchange.create_market_sell_order(pair, amount)
         except Exception as exc:
             logger.warning("Failed to place %s order: %s", side, exc)
             return None
 
+    def check_system_health(self) -> None:
+        """Log basic system health metrics using psutil."""
+        cpu = psutil.cpu_percent()
+        mem = psutil.virtual_memory().percent
+        disk = psutil.disk_usage("/").percent
+        logger.debug("System health - CPU: %.1f%% MEM: %.1f%% DISK: %.1f%%", cpu, mem, disk)
+
     def evaluate(self):
-        """Evaluate strategies and manage positions."""
-        current_price = None
-        try:
-            current_price = self.exchange.fetch_ticker(config.TRADING_PAIR)["last"]
-        except Exception as exc:
-            logger.warning("Failed to fetch ticker: %s", exc)
-
-        entry_votes = []
-        exit_votes = []
-        for strat in self.strategies:
+        """Evaluate strategies and manage positions for all pairs."""
+        self.check_system_health()
+        # Entry checks for each pair
+        for pair in config.TRADING_PAIRS:
             try:
-                if strat.should_enter():
-                    entry_votes.append(strat)
-                if self.positions and strat.should_exit(self.positions[0]):
-                    exit_votes.append(strat)
-            except Exception:
-                logger.exception("Error in strategy %s", strat.__class__.__name__)
+                current_price = self.exchange.fetch_ticker(pair)["last"]
+            except Exception as exc:
+                logger.warning("Failed to fetch ticker for %s: %s", pair, exc)
+                continue
 
-        if not self.positions and len(entry_votes) >= config.ENTRY_THRESHOLD and current_price is not None:
-            price = current_price
-            if self.place_order("buy", config.ORDER_SIZE):
-                self.positions.append(Position(price, config.ORDER_SIZE, "combined"))
-                self.record_trade("enter", price, config.ORDER_SIZE, "combined")
-                logger.info("Entered position at %s based on %d strategies", price, len(entry_votes))
+            entry_votes = [s for s in self.strategies if s.pair == pair and s.should_enter()]
+            if len(entry_votes) >= config.ENTRY_THRESHOLD:
+                if self.place_order("buy", pair, config.ORDER_SIZE):
+                    self.positions.append(Position(pair, current_price, config.ORDER_SIZE, "combined"))
+                    self.record_trade(pair, "enter", current_price, config.ORDER_SIZE, "combined")
+                    logger.info("Entered %s based on %d strategies", pair, len(entry_votes))
 
-        elif self.positions:
-            pos = self.positions[0]
+        # Exit checks for each open position
+        for pos in list(self.positions):
+            try:
+                current_price = self.exchange.fetch_ticker(pos.pair)["last"]
+            except Exception as exc:
+                logger.warning("Failed to fetch ticker for %s: %s", pos.pair, exc)
+                current_price = pos.entry_price
+
+            exit_votes = [s for s in self.strategies if s.pair == pos.pair and s.should_exit(pos)]
+            change_pct = (current_price - pos.entry_price) / pos.entry_price * 100
             risk_exit = False
-            if current_price is not None:
-                change_pct = (current_price - pos.entry_price) / pos.entry_price * 100
-                if config.TAKE_PROFIT_PCT and change_pct >= config.TAKE_PROFIT_PCT:
-                    logger.info("Take profit reached: %.2f%%", change_pct)
-                    risk_exit = True
-                elif config.STOP_LOSS_PCT and change_pct <= -config.STOP_LOSS_PCT:
-                    logger.info("Stop loss reached: %.2f%%", change_pct)
-                    risk_exit = True
+            if config.TAKE_PROFIT_PCT and change_pct >= config.TAKE_PROFIT_PCT:
+                logger.info("Take profit reached on %s: %.2f%%", pos.pair, change_pct)
+                risk_exit = True
+            elif config.STOP_LOSS_PCT and change_pct <= -config.STOP_LOSS_PCT:
+                logger.info("Stop loss reached on %s: %.2f%%", pos.pair, change_pct)
+                risk_exit = True
 
             if len(exit_votes) >= config.EXIT_THRESHOLD or risk_exit:
-                if current_price is None:
-                    current_price = pos.entry_price
-                if self.place_order("sell", pos.amount):
+                if self.place_order("sell", pos.pair, pos.amount):
                     pnl = (current_price - pos.entry_price) * pos.amount
                     self.closed_profit += pnl
-                    logger.info("Exiting position opened at %s with P/L %.2f", pos.entry_price, pnl)
-                    self.record_trade("exit", current_price, pos.amount, "combined")
-                    self.positions.clear()
+                    logger.info("Exiting %s opened at %.2f with P/L %.2f", pos.pair, pos.entry_price, pnl)
+                    self.record_trade(pos.pair, "exit", current_price, pos.amount, "combined")
+                    self.positions.remove(pos)
 

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -4,11 +4,13 @@ import os
 # In a real setup, you would load these from environment variables
 # or a configuration file.
 
-# API credentials for exchanges can be set via env variables.
+# Exchange identifier and credentials.  These can be overridden
+# via environment variables or command-line arguments.
+EXCHANGE_ID = os.getenv("EXCHANGE_ID", "binance")
 EXCHANGE_API_KEY = os.getenv("EXCHANGE_API_KEY", "your-key")
 EXCHANGE_SECRET = os.getenv("EXCHANGE_SECRET", "your-secret")
 
-# Default trading pair and timeframe
+# Default trading pair and timeframe used when none are supplied by the user.
 TRADING_PAIR = os.getenv("TRADING_PAIR", "BTC/USDT")
 TIMEFRAME = os.getenv("TIMEFRAME", "1h")
 
@@ -18,6 +20,14 @@ STRATEGIES = [
     "RSIStrategy",
 ]
 
-# Database or file path for persisting trades
+# Path used to persist executed trades.  The bot will append to this
+# CSV file whenever a new position is opened or closed.
 DATA_PATH = os.getenv("DATA_PATH", "trades.csv")
+
+# Log verbosity and dashboard port.
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+DASHBOARD_PORT = int(os.getenv("DASHBOARD_PORT", "5000"))
+
+# Evaluation interval in seconds for running the strategies.
+REFRESH_INTERVAL = int(os.getenv("REFRESH_INTERVAL", "60"))
 

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -14,11 +14,16 @@ EXCHANGE_SECRET = os.getenv("EXCHANGE_SECRET", "your-secret")
 TRADING_PAIR = os.getenv("TRADING_PAIR", "BTC/USDT")
 TIMEFRAME = os.getenv("TIMEFRAME", "1h")
 
-# List of strategy class names to load dynamically
-STRATEGIES = [
-    "MovingAverageStrategy",
-    "RSIStrategy",
-]
+# List of strategy class names to load dynamically. The environment
+# variable STRATEGIES can override this with a comma separated list.
+_strategies_env = os.getenv("STRATEGIES")
+if _strategies_env:
+    STRATEGIES = [s.strip() for s in _strategies_env.split(",") if s.strip()]
+else:
+    STRATEGIES = [
+        "MovingAverageStrategy",
+        "RSIStrategy",
+    ]
 
 # Path used to persist executed trades.  The bot will append to this
 # CSV file whenever a new position is opened or closed.
@@ -40,4 +45,9 @@ SIMULATE = os.getenv("SIMULATE", "true").lower() in ("1", "true", "yes")
 # Threshold for how many strategies must agree before entering or exiting.
 ENTRY_THRESHOLD = int(os.getenv("ENTRY_THRESHOLD", "1"))
 EXIT_THRESHOLD = int(os.getenv("EXIT_THRESHOLD", "1"))
+
+# Risk management settings. Percentages are expressed as positive numbers.
+# Set to 0 to disable.
+STOP_LOSS_PCT = float(os.getenv("STOP_LOSS_PCT", "0"))
+TAKE_PROFIT_PCT = float(os.getenv("TAKE_PROFIT_PCT", "0"))
 

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -14,6 +14,14 @@ EXCHANGE_SECRET = os.getenv("EXCHANGE_SECRET", "your-secret")
 TRADING_PAIR = os.getenv("TRADING_PAIR", "BTC/USDT")
 TIMEFRAME = os.getenv("TIMEFRAME", "1h")
 
+# Comma separated list of trading pairs.  When multiple pairs are provided
+# the bot will manage independent positions for each of them.
+_pairs_env = os.getenv("TRADING_PAIRS")
+if _pairs_env:
+    TRADING_PAIRS = [p.strip() for p in _pairs_env.split(",") if p.strip()]
+else:
+    TRADING_PAIRS = [TRADING_PAIR]
+
 # List of strategy class names to load dynamically. The environment
 # variable STRATEGIES can override this with a comma separated list.
 _strategies_env = os.getenv("STRATEGIES")
@@ -23,6 +31,8 @@ else:
     STRATEGIES = [
         "MovingAverageStrategy",
         "RSIStrategy",
+        "BollingerBandStrategy",
+        "AdaptiveMovingAverageStrategy",
     ]
 
 # Path used to persist executed trades.  The bot will append to this

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -31,3 +31,13 @@ DASHBOARD_PORT = int(os.getenv("DASHBOARD_PORT", "5000"))
 # Evaluation interval in seconds for running the strategies.
 REFRESH_INTERVAL = int(os.getenv("REFRESH_INTERVAL", "60"))
 
+# Trade amount per order when entering or exiting positions.
+ORDER_SIZE = float(os.getenv("ORDER_SIZE", "1"))
+
+# Simulation mode skips actual order placement.
+SIMULATE = os.getenv("SIMULATE", "true").lower() in ("1", "true", "yes")
+
+# Threshold for how many strategies must agree before entering or exiting.
+ENTRY_THRESHOLD = int(os.getenv("ENTRY_THRESHOLD", "1"))
+EXIT_THRESHOLD = int(os.getenv("EXIT_THRESHOLD", "1"))
+

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -1,0 +1,23 @@
+import os
+
+# Basic configuration for the trading bot.
+# In a real setup, you would load these from environment variables
+# or a configuration file.
+
+# API credentials for exchanges can be set via env variables.
+EXCHANGE_API_KEY = os.getenv("EXCHANGE_API_KEY", "your-key")
+EXCHANGE_SECRET = os.getenv("EXCHANGE_SECRET", "your-secret")
+
+# Default trading pair and timeframe
+TRADING_PAIR = os.getenv("TRADING_PAIR", "BTC/USDT")
+TIMEFRAME = os.getenv("TIMEFRAME", "1h")
+
+# List of strategy class names to load dynamically
+STRATEGIES = [
+    "MovingAverageStrategy",
+    "RSIStrategy",
+]
+
+# Database or file path for persisting trades
+DATA_PATH = os.getenv("DATA_PATH", "trades.csv")
+

--- a/trading_bot/dashboard.py
+++ b/trading_bot/dashboard.py
@@ -1,4 +1,8 @@
 from flask import Flask, render_template_string
+import csv
+import os
+
+from . import config
 
 app = Flask(__name__)
 
@@ -7,17 +11,41 @@ HTML = """
 <title>Trading Bot Dashboard</title>
 <h1>Open Positions</h1>
 <table border="1">
-    <tr><th>Strategy</th><th>Entry Price</th><th>Amount</th></tr>
+    <tr><th>Strategy</th><th>Entry Price</th><th>Amount</th><th>P/L</th></tr>
     {% for p in positions %}
-    <tr><td>{{ p.strategy }}</td><td>{{ p.entry_price }}</td><td>{{ p.amount }}</td></tr>
+    <tr><td>{{ p.strategy }}</td><td>{{ p.entry_price }}</td><td>{{ p.amount }}</td><td>{{ p.pnl }}</td></tr>
     {% endfor %}
 </table>
+<p><a href="/trades">Trade history</a></p>
 """
 
 def create_app(bot):
     @app.route("/")
     def index():
-        return render_template_string(HTML, positions=bot.positions)
+        positions = []
+        for p in bot.positions:
+            current = bot.exchange.fetch_ticker(config.TRADING_PAIR)["last"]
+            pnl = (current - p.entry_price) * p.amount
+            positions.append({"strategy": p.strategy, "entry_price": p.entry_price, "amount": p.amount, "pnl": round(pnl, 2)})
+        return render_template_string(HTML, positions=positions)
+
+    @app.route("/trades")
+    def trades():
+        if not bot.data_path or not os.path.exists(bot.data_path):
+            rows = []
+        else:
+            with open(bot.data_path) as f:
+                rows = list(csv.reader(f))[1:][-20:]
+        history_html = """
+        <h1>Recent Trades</h1>
+        <table border='1'>
+            <tr><th>Timestamp</th><th>Action</th><th>Price</th><th>Amount</th><th>Strategy</th></tr>
+            {% for r in rows %}
+            <tr>{% for c in r %}<td>{{ c }}</td>{% endfor %}</tr>
+            {% endfor %}
+        </table>
+        <p><a href='/'>Back</a></p>
+        """
+        return render_template_string(history_html, rows=rows)
 
     return app
-

--- a/trading_bot/dashboard.py
+++ b/trading_bot/dashboard.py
@@ -1,4 +1,6 @@
 from flask import Flask, render_template_string
+import base64
+from io import BytesIO
 import csv
 import os
 
@@ -10,16 +12,17 @@ HTML = """
 <!doctype html>
 <title>Trading Bot Dashboard</title>
 <h1>Trading Bot Dashboard</h1>
-<p>Pair: {{ pair }} | Timeframe: {{ timeframe }} | Exchange: {{ exchange }} | Simulate: {{ simulate }}</p>
+<p>Pairs: {{ pairs }} | Timeframe: {{ timeframe }} | Exchange: {{ exchange }} | Simulate: {{ simulate }}</p>
 <p>Refresh: {{ refresh }}s | Total Closed P/L: {{ total_pnl }}</p>
 <h2>Open Positions</h2>
 <table border="1">
-    <tr><th>Strategy</th><th>Entry Price</th><th>Amount</th><th>P/L</th></tr>
+    <tr><th>Pair</th><th>Strategy</th><th>Entry Price</th><th>Amount</th><th>P/L</th></tr>
     {% for p in positions %}
-    <tr><td>{{ p.strategy }}</td><td>{{ p.entry_price }}</td><td>{{ p.amount }}</td><td>{{ p.pnl }}</td></tr>
+    <tr><td>{{ p.pair }}</td><td>{{ p.strategy }}</td><td>{{ p.entry_price }}</td><td>{{ p.amount }}</td><td>{{ p.pnl }}</td></tr>
     {% endfor %}
 </table>
 <p><a href="/trades">Trade history</a></p>
+<img src="data:image/png;base64,{{ chart }}" alt="P/L chart" />
 """
 
 def create_app(bot):
@@ -27,18 +30,20 @@ def create_app(bot):
     def index():
         positions = []
         for p in bot.positions:
-            current = bot.exchange.fetch_ticker(config.TRADING_PAIR)["last"]
+            current = bot.exchange.fetch_ticker(p.pair)["last"]
             pnl = (current - p.entry_price) * p.amount
-            positions.append({"strategy": p.strategy, "entry_price": p.entry_price, "amount": p.amount, "pnl": round(pnl, 2)})
+            positions.append({"pair": p.pair, "strategy": p.strategy, "entry_price": p.entry_price, "amount": p.amount, "pnl": round(pnl, 2)})
+        chart = generate_pnl_chart(bot.data_path)
         return render_template_string(
             HTML,
             positions=positions,
-            pair=config.TRADING_PAIR,
+            pairs=", ".join(config.TRADING_PAIRS),
             timeframe=config.TIMEFRAME,
             exchange=config.EXCHANGE_ID,
             simulate=config.SIMULATE,
             refresh=config.REFRESH_INTERVAL,
             total_pnl=round(bot.closed_profit, 2),
+            chart=chart,
         )
 
     @app.route("/trades")
@@ -51,7 +56,7 @@ def create_app(bot):
         history_html = """
         <h1>Recent Trades</h1>
         <table border='1'>
-            <tr><th>Timestamp</th><th>Action</th><th>Price</th><th>Amount</th><th>Strategy</th></tr>
+            <tr><th>Timestamp</th><th>Pair</th><th>Action</th><th>Price</th><th>Amount</th><th>Strategy</th></tr>
             {% for r in rows %}
             <tr>{% for c in r %}<td>{{ c }}</td>{% endfor %}</tr>
             {% endfor %}
@@ -59,5 +64,33 @@ def create_app(bot):
         <p><a href='/'>Back</a></p>
         """
         return render_template_string(history_html, rows=rows)
+
+    def generate_pnl_chart(csv_path):
+        if not csv_path or not os.path.exists(csv_path):
+            return ""
+        with open(csv_path) as f:
+            rows = list(csv.reader(f))[1:]
+        pnl = 0
+        entries = {}
+        curve = []
+        for ts, pair, action, price, amount, _ in rows:
+            price = float(price)
+            amount = float(amount)
+            if action == "enter":
+                entries.setdefault(pair, []).append((price, amount))
+            else:
+                entry_price, amt = entries.get(pair, [(price, amount)]).pop(0)
+                pnl += (price - entry_price) * amt
+            curve.append(pnl)
+        if not curve:
+            return ""
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        ax.plot(curve)
+        ax.set_title("Cumulative P/L")
+        buf = BytesIO()
+        fig.savefig(buf, format="png")
+        plt.close(fig)
+        return base64.b64encode(buf.getvalue()).decode()
 
     return app

--- a/trading_bot/dashboard.py
+++ b/trading_bot/dashboard.py
@@ -1,0 +1,23 @@
+from flask import Flask, render_template_string
+
+app = Flask(__name__)
+
+HTML = """
+<!doctype html>
+<title>Trading Bot Dashboard</title>
+<h1>Open Positions</h1>
+<table border="1">
+    <tr><th>Strategy</th><th>Entry Price</th><th>Amount</th></tr>
+    {% for p in positions %}
+    <tr><td>{{ p.strategy }}</td><td>{{ p.entry_price }}</td><td>{{ p.amount }}</td></tr>
+    {% endfor %}
+</table>
+"""
+
+def create_app(bot):
+    @app.route("/")
+    def index():
+        return render_template_string(HTML, positions=bot.positions)
+
+    return app
+

--- a/trading_bot/dashboard.py
+++ b/trading_bot/dashboard.py
@@ -9,7 +9,10 @@ app = Flask(__name__)
 HTML = """
 <!doctype html>
 <title>Trading Bot Dashboard</title>
-<h1>Open Positions</h1>
+<h1>Trading Bot Dashboard</h1>
+<p>Pair: {{ pair }} | Timeframe: {{ timeframe }} | Exchange: {{ exchange }} | Simulate: {{ simulate }}</p>
+<p>Total Closed P/L: {{ total_pnl }}</p>
+<h2>Open Positions</h2>
 <table border="1">
     <tr><th>Strategy</th><th>Entry Price</th><th>Amount</th><th>P/L</th></tr>
     {% for p in positions %}
@@ -27,7 +30,15 @@ def create_app(bot):
             current = bot.exchange.fetch_ticker(config.TRADING_PAIR)["last"]
             pnl = (current - p.entry_price) * p.amount
             positions.append({"strategy": p.strategy, "entry_price": p.entry_price, "amount": p.amount, "pnl": round(pnl, 2)})
-        return render_template_string(HTML, positions=positions)
+        return render_template_string(
+            HTML,
+            positions=positions,
+            pair=config.TRADING_PAIR,
+            timeframe=config.TIMEFRAME,
+            exchange=config.EXCHANGE_ID,
+            simulate=config.SIMULATE,
+            total_pnl=round(bot.closed_profit, 2),
+        )
 
     @app.route("/trades")
     def trades():

--- a/trading_bot/dashboard.py
+++ b/trading_bot/dashboard.py
@@ -11,7 +11,7 @@ HTML = """
 <title>Trading Bot Dashboard</title>
 <h1>Trading Bot Dashboard</h1>
 <p>Pair: {{ pair }} | Timeframe: {{ timeframe }} | Exchange: {{ exchange }} | Simulate: {{ simulate }}</p>
-<p>Total Closed P/L: {{ total_pnl }}</p>
+<p>Refresh: {{ refresh }}s | Total Closed P/L: {{ total_pnl }}</p>
 <h2>Open Positions</h2>
 <table border="1">
     <tr><th>Strategy</th><th>Entry Price</th><th>Amount</th><th>P/L</th></tr>
@@ -37,6 +37,7 @@ def create_app(bot):
             timeframe=config.TIMEFRAME,
             exchange=config.EXCHANGE_ID,
             simulate=config.SIMULATE,
+            refresh=config.REFRESH_INTERVAL,
             total_pnl=round(bot.closed_profit, 2),
         )
 

--- a/trading_bot/run_bot.py
+++ b/trading_bot/run_bot.py
@@ -17,7 +17,8 @@ def run_bot(bot: TradingBot):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Run the trading bot")
-    parser.add_argument("--pair", default=config.TRADING_PAIR, help="Trading pair, e.g. BTC/USDT")
+    parser.add_argument("--pair", default=config.TRADING_PAIR, help="Primary trading pair, e.g. BTC/USDT")
+    parser.add_argument("--pairs", default=','.join(config.TRADING_PAIRS), help="Comma-separated list of trading pairs")
     parser.add_argument("--timeframe", default=config.TIMEFRAME, help="OHLCV timeframe")
     parser.add_argument("--exchange", default=config.EXCHANGE_ID, help="Exchange id from ccxt")
     parser.add_argument("--port", type=int, default=config.DASHBOARD_PORT, help="Dashboard port")
@@ -48,6 +49,7 @@ def main(argv=None):
 
     # Update configuration based on CLI args
     config.TRADING_PAIR = args.pair
+    config.TRADING_PAIRS = [p.strip() for p in args.pairs.split(',') if p.strip()]
     config.TIMEFRAME = args.timeframe
     config.EXCHANGE_ID = args.exchange
     config.DASHBOARD_PORT = args.port

--- a/trading_bot/run_bot.py
+++ b/trading_bot/run_bot.py
@@ -21,6 +21,10 @@ def main(argv=None):
     parser.add_argument("--timeframe", default=config.TIMEFRAME, help="OHLCV timeframe")
     parser.add_argument("--exchange", default=config.EXCHANGE_ID, help="Exchange id from ccxt")
     parser.add_argument("--port", type=int, default=config.DASHBOARD_PORT, help="Dashboard port")
+    parser.add_argument("--order-size", type=float, default=config.ORDER_SIZE, help="Amount to trade")
+    parser.add_argument("--simulate", action="store_true", default=config.SIMULATE, help="Run without placing real orders")
+    parser.add_argument("--entry-threshold", type=int, default=config.ENTRY_THRESHOLD, help="Number of strategies required to enter")
+    parser.add_argument("--exit-threshold", type=int, default=config.EXIT_THRESHOLD, help="Number of strategies required to exit")
     args = parser.parse_args(argv)
 
     # Update configuration based on CLI args
@@ -28,6 +32,10 @@ def main(argv=None):
     config.TIMEFRAME = args.timeframe
     config.EXCHANGE_ID = args.exchange
     config.DASHBOARD_PORT = args.port
+    config.ORDER_SIZE = args.order_size
+    config.SIMULATE = args.simulate
+    config.ENTRY_THRESHOLD = args.entry_threshold
+    config.EXIT_THRESHOLD = args.exit_threshold
 
     bot = TradingBot(exchange_id=args.exchange)
     app = create_app(bot)

--- a/trading_bot/run_bot.py
+++ b/trading_bot/run_bot.py
@@ -23,6 +23,8 @@ def main(argv=None):
     parser.add_argument("--port", type=int, default=config.DASHBOARD_PORT, help="Dashboard port")
     parser.add_argument("--order-size", type=float, default=config.ORDER_SIZE, help="Amount to trade")
     parser.add_argument("--simulate", action="store_true", default=config.SIMULATE, help="Run without placing real orders")
+    parser.add_argument("--refresh-interval", type=int, default=config.REFRESH_INTERVAL, help="Seconds between evaluations")
+    parser.add_argument("--data-path", default=config.DATA_PATH, help="CSV file to persist trades")
     parser.add_argument("--entry-threshold", type=int, default=config.ENTRY_THRESHOLD, help="Number of strategies required to enter")
     parser.add_argument("--exit-threshold", type=int, default=config.EXIT_THRESHOLD, help="Number of strategies required to exit")
     parser.add_argument(
@@ -51,6 +53,8 @@ def main(argv=None):
     config.DASHBOARD_PORT = args.port
     config.ORDER_SIZE = args.order_size
     config.SIMULATE = args.simulate
+    config.REFRESH_INTERVAL = args.refresh_interval
+    config.DATA_PATH = args.data_path
     config.ENTRY_THRESHOLD = args.entry_threshold
     config.EXIT_THRESHOLD = args.exit_threshold
     config.STRATEGIES = [s.strip() for s in args.strategies.split(',') if s.strip()]

--- a/trading_bot/run_bot.py
+++ b/trading_bot/run_bot.py
@@ -1,0 +1,23 @@
+"""Entry point for running the trading bot with dashboard."""
+import threading
+import time
+
+from .bot import TradingBot
+from .dashboard import create_app
+
+
+def run_bot(bot: TradingBot):
+    while True:
+        bot.evaluate()
+        time.sleep(60)  # run every minute
+
+
+def main():
+    bot = TradingBot()
+    app = create_app(bot)
+    threading.Thread(target=run_bot, args=(bot,), daemon=True).start()
+    app.run(port=5000)
+
+
+if __name__ == "__main__":
+    main()

--- a/trading_bot/run_bot.py
+++ b/trading_bot/run_bot.py
@@ -25,6 +25,23 @@ def main(argv=None):
     parser.add_argument("--simulate", action="store_true", default=config.SIMULATE, help="Run without placing real orders")
     parser.add_argument("--entry-threshold", type=int, default=config.ENTRY_THRESHOLD, help="Number of strategies required to enter")
     parser.add_argument("--exit-threshold", type=int, default=config.EXIT_THRESHOLD, help="Number of strategies required to exit")
+    parser.add_argument(
+        "--strategies",
+        default=','.join(config.STRATEGIES),
+        help="Comma-separated list of strategy class names",
+    )
+    parser.add_argument(
+        "--stop-loss",
+        type=float,
+        default=config.STOP_LOSS_PCT,
+        help="Stop loss percentage",
+    )
+    parser.add_argument(
+        "--take-profit",
+        type=float,
+        default=config.TAKE_PROFIT_PCT,
+        help="Take profit percentage",
+    )
     args = parser.parse_args(argv)
 
     # Update configuration based on CLI args
@@ -36,6 +53,9 @@ def main(argv=None):
     config.SIMULATE = args.simulate
     config.ENTRY_THRESHOLD = args.entry_threshold
     config.EXIT_THRESHOLD = args.exit_threshold
+    config.STRATEGIES = [s.strip() for s in args.strategies.split(',') if s.strip()]
+    config.STOP_LOSS_PCT = args.stop_loss
+    config.TAKE_PROFIT_PCT = args.take_profit
 
     bot = TradingBot(exchange_id=args.exchange)
     app = create_app(bot)

--- a/trading_bot/run_bot.py
+++ b/trading_bot/run_bot.py
@@ -1,22 +1,38 @@
 """Entry point for running the trading bot with dashboard."""
+import argparse
 import threading
 import time
 
 from .bot import TradingBot
 from .dashboard import create_app
+from . import config
 
 
 def run_bot(bot: TradingBot):
+    """Continuously evaluate strategies using the configured interval."""
     while True:
         bot.evaluate()
-        time.sleep(60)  # run every minute
+        time.sleep(config.REFRESH_INTERVAL)
 
 
-def main():
-    bot = TradingBot()
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run the trading bot")
+    parser.add_argument("--pair", default=config.TRADING_PAIR, help="Trading pair, e.g. BTC/USDT")
+    parser.add_argument("--timeframe", default=config.TIMEFRAME, help="OHLCV timeframe")
+    parser.add_argument("--exchange", default=config.EXCHANGE_ID, help="Exchange id from ccxt")
+    parser.add_argument("--port", type=int, default=config.DASHBOARD_PORT, help="Dashboard port")
+    args = parser.parse_args(argv)
+
+    # Update configuration based on CLI args
+    config.TRADING_PAIR = args.pair
+    config.TIMEFRAME = args.timeframe
+    config.EXCHANGE_ID = args.exchange
+    config.DASHBOARD_PORT = args.port
+
+    bot = TradingBot(exchange_id=args.exchange)
     app = create_app(bot)
     threading.Thread(target=run_bot, args=(bot,), daemon=True).start()
-    app.run(port=5000)
+    app.run(port=args.port)
 
 
 if __name__ == "__main__":

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -1,0 +1,74 @@
+import abc
+import pandas as pd
+from typing import Any
+
+class Strategy(abc.ABC):
+    """Abstract base class for trading strategies."""
+
+    def __init__(self, exchange, pair: str, timeframe: str):
+        self.exchange = exchange
+        self.pair = pair
+        self.timeframe = timeframe
+        self.data = pd.DataFrame()
+
+    def update_data(self):
+        """Fetch recent OHLCV data from the exchange."""
+        ohlcv = self.exchange.fetch_ohlcv(self.pair, timeframe=self.timeframe)
+        self.data = pd.DataFrame(ohlcv, columns=[
+            "timestamp", "open", "high", "low", "close", "volume"
+        ])
+
+    @abc.abstractmethod
+    def should_enter(self) -> bool:
+        """Return True if a position should be opened."""
+
+    @abc.abstractmethod
+    def should_exit(self, position: Any) -> bool:
+        """Return True if a position should be closed."""
+
+class MovingAverageStrategy(Strategy):
+    """Simple moving average crossover strategy."""
+
+    short_window = 7
+    long_window = 25
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        if len(self.data) < self.long_window:
+            return False
+        short_ma = self.data["close"].rolling(self.short_window).mean().iloc[-1]
+        long_ma = self.data["close"].rolling(self.long_window).mean().iloc[-1]
+        return short_ma > long_ma
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        short_ma = self.data["close"].rolling(self.short_window).mean().iloc[-1]
+        long_ma = self.data["close"].rolling(self.long_window).mean().iloc[-1]
+        return short_ma < long_ma
+
+class RSIStrategy(Strategy):
+    """Relative Strength Index strategy."""
+
+    rsi_period = 14
+    overbought = 70
+    oversold = 30
+
+    def _rsi(self) -> float:
+        delta = self.data["close"].diff()
+        up = delta.clip(lower=0).ewm(alpha=1 / self.rsi_period).mean()
+        down = -delta.clip(upper=0).ewm(alpha=1 / self.rsi_period).mean()
+        rs = up / down
+        return 100 - (100 / (1 + rs)).iloc[-1]
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        if len(self.data) < self.rsi_period:
+            return False
+        return self._rsi() < self.oversold
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        if len(self.data) < self.rsi_period:
+            return False
+        return self._rsi() > self.overbought
+

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -1,6 +1,10 @@
 import abc
-import pandas as pd
+import logging
 from typing import Any
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 class Strategy(abc.ABC):
     """Abstract base class for trading strategies."""
@@ -13,10 +17,15 @@ class Strategy(abc.ABC):
 
     def update_data(self):
         """Fetch recent OHLCV data from the exchange."""
-        ohlcv = self.exchange.fetch_ohlcv(self.pair, timeframe=self.timeframe)
-        self.data = pd.DataFrame(ohlcv, columns=[
-            "timestamp", "open", "high", "low", "close", "volume"
-        ])
+        try:
+            ohlcv = self.exchange.fetch_ohlcv(self.pair, timeframe=self.timeframe)
+        except Exception as exc:
+            logger.warning("Failed to fetch OHLCV data: %s", exc)
+            return
+        self.data = pd.DataFrame(
+            ohlcv,
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
+        )
 
     @abc.abstractmethod
     def should_enter(self) -> bool:

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -81,3 +81,52 @@ class RSIStrategy(Strategy):
             return False
         return self._rsi() > self.overbought
 
+
+class BollingerBandStrategy(Strategy):
+    """Bollinger Bands mean reversion strategy."""
+
+    window = 20
+    num_std = 2
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        if len(self.data) < self.window:
+            return False
+        ma = self.data["close"].rolling(self.window).mean().iloc[-1]
+        std = self.data["close"].rolling(self.window).std().iloc[-1]
+        lower = ma - self.num_std * std
+        price = self.data["close"].iloc[-1]
+        return price < lower
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        if len(self.data) < self.window:
+            return False
+        ma = self.data["close"].rolling(self.window).mean().iloc[-1]
+        price = self.data["close"].iloc[-1]
+        return price > ma
+
+
+class AdaptiveMovingAverageStrategy(MovingAverageStrategy):
+    """Moving average crossover with auto-adjusted windows."""
+
+    def update_windows(self):
+        """Adjust windows based on historical volatility."""
+        closes = self.data["close"]
+        if len(closes) < 50:
+            return
+        vol = closes.pct_change().rolling(50).std().iloc[-1]
+        factor = max(1, min(5, round(vol * 100)))
+        self.short_window = 5 * factor
+        self.long_window = 20 * factor
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        self.update_windows()
+        return super().should_enter()
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        self.update_windows()
+        return super().should_exit(position)
+


### PR DESCRIPTION
## Summary
- add `trading_bot` package with a simple strategy framework
- implement moving average and RSI strategies
- connect to exchanges using ccxt
- include a Flask dashboard to view open positions
- provide a run script to launch the bot and dashboard

## Testing
- `python -m trading_bot.run_bot --help` *(fails: NetworkError when connecting to Binance)*

------
https://chatgpt.com/codex/tasks/task_e_68814107947083239e1ca58c399258f0