### PR TITLE
Add adaptive strategy weights

### DIFF
--- a/jasperboy/README.md
+++ b/jasperboy/README.md
@@ -1,0 +1,78 @@
+# JasperBoy Trading Bot
+
+This folder contains a small experimental trading bot using `ccxt`.  It can
+run in simulation mode or connect directly to an exchange.  Strategies are
+loaded dynamically and evaluated periodically.  A small Flask dashboard shows
+open positions, recent trades and a cumulative P/L chart.
+
+## Setup
+
+Install dependencies in a virtual environment:
+
+```bash
+pip install -r ../requirements.txt
+```
+
+## Usage
+
+Run the bot with the default configuration:
+
+```bash
+python -m jasperboy.run_bot
+```
+
+Key options include:
+
+- `--pairs` to specify a comma separated list of trading pairs
+- `--auto-pairs` to let the bot choose the most liquid pairs automatically
+- `--strategies` to choose which strategies to load
+- `--auto-strategies` to load all built-in strategies automatically
+- `--simulate` to disable real order placement
+- `--refresh-interval` seconds between evaluations
+- `--max-positions` limit concurrent open trades
+- `--partial-tp` percentage gain to trigger a partial take profit
+- `--trailing-stop` trailing stop percentage
+- `--weight-threshold` minimum combined strategy weight before a trade
+
+Strategy weights adjust automatically based on trade outcomes and are stored in
+`weights.json`.
+
+The dashboard will start on the configured port (default `5000`).
+
+### Backtesting
+
+Historical strategies can be tested offline with the built in backtester.  It
+reports total profit along with common performance metrics:
+
+```bash
+python -m jasperboy.backtest --pair BTC/USDT --timeframe 1h --limit 500
+```
+
+This downloads OHLCV data using `ccxt` and runs the configured strategies.
+At the end of the run it prints profit, Sharpe ratio and maximum drawdown.
+
+Environment variables can also configure the bot.  See `config.py` for the
+full list, including `AUTO_SELECT_PAIRS` and `AUTO_SELECT_STRATEGIES` which
+enable automatic selection of pairs and strategies.
+`WEIGHT_THRESHOLD` adjusts the minimum combined weight of strategies before
+trades are executed, while strategy scores are saved in `weights.json`.
+
+Trading activity is logged to `trading.log` while system events are logged to
+`system.log`.
+
+## Running in Google Colab
+
+The bot can also be tested in a Colab notebook using simulation mode.  Create a
+new notebook and run the following cells:
+
+```python
+!git clone https://github.com/your_username/your_repo.git
+%cd your_repo
+!pip install -r requirements.txt
+!python -m jasperboy.run_bot --simulate --refresh-interval 30
+```
+
+Replace the repository URL with the location of your fork.  The `--simulate`
+flag disables real order placement so the bot can run without credentials.  A
+small Flask dashboard will be available on port `5000`.  You can use tools like
+`pyngrok` if you need to expose the dashboard outside of Colab.

--- a/jasperboy/__init__.py
+++ b/jasperboy/__init__.py
@@ -1,0 +1,6 @@
+"""Trading bot package."""
+
+from .bot import TradingBot
+from .backtest import Backtester
+
+__all__ = ["TradingBot", "Backtester"]

--- a/jasperboy/backtest.py
+++ b/jasperboy/backtest.py
@@ -1,0 +1,144 @@
+import argparse
+import logging
+from typing import List
+
+import ccxt
+import pandas as pd
+import json
+import os
+
+from .strategy import Strategy
+from .bot import Position
+from . import config
+
+logger = logging.getLogger("backtest")
+
+class Backtester:
+    """Simple backtesting engine using historical OHLCV data."""
+
+    def __init__(
+        self,
+        exchange_id: str,
+        pair: str,
+        timeframe: str,
+        strategies: List[Strategy],
+        order_size: float = 1,
+    ):
+        self.exchange = getattr(ccxt, exchange_id)()
+        self.pair = pair
+        self.timeframe = timeframe
+        self.strategies = strategies
+        self.order_size = order_size
+        self.positions: List[Position] = []
+        self.closed_profit = 0.0
+        self.profit_curve: List[float] = []
+        self.metrics: dict[str, float] = {}
+
+    def run(self, limit: int = 500):
+        """Execute backtest and compute performance metrics."""
+        ohlcv = self.exchange.fetch_ohlcv(
+            self.pair, timeframe=self.timeframe, limit=limit
+        )
+        df = pd.DataFrame(
+            ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"]
+        )
+        for i in range(len(df)):
+            window = df.iloc[: i + 1]
+            price = window["close"].iloc[-1]
+            for s in self.strategies:
+                s.data = window
+            if not self.positions:
+                entry_votes = [s for s in self.strategies if s.should_enter()]
+                weight_sum = sum(getattr(s, "weight", 1.0) for s in entry_votes)
+                if weight_sum >= config.WEIGHT_THRESHOLD:
+                    self.positions.append(
+                        Position(
+                            self.pair,
+                            price,
+                            self.order_size,
+                            "backtest",
+                            highest_price=price,
+                        )
+                    )
+            else:
+                pos = self.positions[0]
+                exit_votes = [s for s in self.strategies if s.should_exit(pos)]
+                weight_exit = sum(getattr(s, "weight", 1.0) for s in exit_votes)
+                if weight_exit >= config.WEIGHT_THRESHOLD:
+                    pnl = (price - pos.entry_price) * pos.amount
+                    self.closed_profit += pnl
+                    self.positions.clear()
+            # Track equity curve
+            equity = self.closed_profit
+            if self.positions:
+                equity += (price - self.positions[0].entry_price) * self.positions[0].amount
+            self.profit_curve.append(equity)
+
+        if self.positions:
+            last_price = df["close"].iloc[-1]
+            pnl = (last_price - self.positions[0].entry_price) * self.positions[0].amount
+            self.closed_profit += pnl
+            self.profit_curve[-1] = self.closed_profit
+
+        self._compute_metrics()
+        return self.closed_profit
+
+    def _compute_metrics(self) -> None:
+        """Calculate sharpe ratio and max drawdown for the profit curve."""
+        if not self.profit_curve:
+            self.metrics = {"sharpe": 0.0, "max_drawdown": 0.0}
+            return
+        curve = pd.Series(self.profit_curve)
+        returns = curve.pct_change().fillna(0)
+        sharpe = 0.0
+        if returns.std() != 0:
+            sharpe = (returns.mean() / returns.std()) * (len(returns) ** 0.5)
+        roll_max = curve.cummax()
+        drawdown = (curve - roll_max) / roll_max
+        max_drawdown = drawdown.min() if not drawdown.empty else 0.0
+        self.metrics = {
+            "sharpe": round(sharpe, 4),
+            "max_drawdown": round(float(max_drawdown), 4),
+        }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run backtest")
+    parser.add_argument("--pair", default=config.TRADING_PAIR)
+    parser.add_argument("--timeframe", default=config.TIMEFRAME)
+    parser.add_argument("--exchange", default=config.EXCHANGE_ID)
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--strategies", default=','.join(config.STRATEGIES))
+    parser.add_argument("--weight-threshold", type=float, default=config.WEIGHT_THRESHOLD)
+    args = parser.parse_args(argv)
+
+    config.TRADING_PAIR = args.pair
+    config.TIMEFRAME = args.timeframe
+    config.EXCHANGE_ID = args.exchange
+    config.STRATEGIES = [s.strip() for s in args.strategies.split(',') if s.strip()]
+    config.WEIGHT_THRESHOLD = args.weight_threshold
+
+    strategies = []
+    weights = {}
+    if os.path.exists(config.WEIGHTS_PATH):
+        with open(config.WEIGHTS_PATH) as f:
+            weights = json.load(f)
+    for name in config.STRATEGIES:
+        mod = __import__('jasperboy.strategy', fromlist=[name])
+        cls = getattr(mod, name)
+        strat = cls(None, args.pair, args.timeframe)
+        strat.weight = weights.get(name, 1.0)
+        strategies.append(strat)
+
+    tester = Backtester(
+        args.exchange, args.pair, args.timeframe, strategies, config.ORDER_SIZE
+    )
+    profit = tester.run(limit=args.limit)
+    metrics = tester.metrics
+    print(
+        f"Backtest completed. Profit: {profit:.2f} | Sharpe: {metrics['sharpe']:.2f} | Max DD: {metrics['max_drawdown']:.2%}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/jasperboy/bot.py
+++ b/jasperboy/bot.py
@@ -1,0 +1,263 @@
+import importlib
+import logging
+from dataclasses import dataclass, field
+from typing import List, Any
+import csv
+import os
+import time
+import json
+
+import pandas as pd
+
+import ccxt
+import psutil
+
+from . import config
+from .strategy import Strategy
+
+# Configure logging with separate files for trading activity and system events
+logging.basicConfig(level=getattr(logging, config.LOG_LEVEL))
+trade_logger = logging.getLogger("trading")
+system_logger = logging.getLogger("system")
+
+trade_handler = logging.FileHandler(config.TRADING_LOG_PATH)
+system_handler = logging.FileHandler(config.SYSTEM_LOG_PATH)
+formatter = logging.Formatter("%(asctime)s %(levelname)s:%(message)s")
+for h in (trade_handler, system_handler):
+    h.setFormatter(formatter)
+
+trade_logger.addHandler(trade_handler)
+system_logger.addHandler(system_handler)
+
+trade_logger.setLevel(getattr(logging, config.LOG_LEVEL))
+system_logger.setLevel(getattr(logging, config.LOG_LEVEL))
+
+@dataclass
+class Position:
+    """Representation of an open position."""
+    pair: str
+    entry_price: float
+    amount: float
+    strategy: str
+    timestamp: float = field(default_factory=time.time)
+    partial_taken: bool = False
+    highest_price: float = 0.0
+    strategies: List[str] = field(default_factory=list)
+
+@dataclass
+class TradingBot:
+    """Core trading bot class."""
+
+    exchange_id: str = config.EXCHANGE_ID
+    strategies: List[Strategy] = field(default_factory=list)
+    positions: List[Position] = field(default_factory=list)
+    closed_profit: float = 0.0
+    data_path: str = config.DATA_PATH
+    weights: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.exchange = getattr(ccxt, self.exchange_id)({
+            "apiKey": config.EXCHANGE_API_KEY,
+            "secret": config.EXCHANGE_SECRET,
+            "enableRateLimit": True,
+        })
+        self.load_weights()
+        self.auto_select_pairs()
+        self.auto_select_strategies()
+        self.load_strategies()
+        # Ensure trade file exists
+        if self.data_path and not os.path.exists(self.data_path):
+            with open(self.data_path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["timestamp", "pair", "action", "price", "amount", "strategy"])
+
+    def record_trade(self, pair: str, action: str, price: float, amount: float, strategy: str) -> None:
+        """Persist trade information to CSV."""
+        if not self.data_path:
+            return
+        with open(self.data_path, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([int(time.time()), pair, action, price, amount, strategy])
+
+    def load_weights(self) -> None:
+        """Load strategy weights from disk."""
+        if os.path.exists(config.WEIGHTS_PATH):
+            with open(config.WEIGHTS_PATH) as f:
+                self.weights = json.load(f)
+        else:
+            self.weights = {name: 1.0 for name in config.STRATEGIES}
+
+    def save_weights(self) -> None:
+        """Persist strategy weights to disk."""
+        if not self.weights:
+            return
+        with open(config.WEIGHTS_PATH, "w") as f:
+            json.dump(self.weights, f)
+
+    def adjust_weights(self, strategies: List[str], profit: float) -> None:
+        """Update weights based on trade outcome."""
+        for name in strategies:
+            w = self.weights.get(name, 1.0)
+            if profit > 0:
+                w += 0.1
+            else:
+                w = max(0.1, w - 0.1)
+            self.weights[name] = round(w, 4)
+        self.save_weights()
+        for strat in self.strategies:
+            if strat.__class__.__name__ in strategies:
+                strat.weight = self.weights[strat.__class__.__name__]
+
+    def auto_select_pairs(self) -> None:
+        """Populate config.TRADING_PAIRS with the most active markets."""
+        if not config.AUTO_SELECT_PAIRS:
+            return
+        try:
+            tickers = self.exchange.fetch_tickers()
+        except Exception as exc:
+            system_logger.warning("Failed to auto select pairs: %s", exc)
+            return
+        candidates = [
+            (sym, info.get("quoteVolume", 0))
+            for sym, info in tickers.items()
+            if sym.endswith("/USDT")
+        ]
+        candidates.sort(key=lambda x: x[1], reverse=True)
+        config.TRADING_PAIRS = [sym for sym, _ in candidates[: config.AUTO_PAIR_COUNT]] or config.TRADING_PAIRS
+        system_logger.info("Auto selected pairs: %s", config.TRADING_PAIRS)
+
+    def auto_select_strategies(self) -> None:
+        """Load all available strategies for automatic selection."""
+        if not config.AUTO_SELECT_STRATEGIES:
+            return
+        module = importlib.import_module("jasperboy.strategy")
+        names = []
+        for name in dir(module):
+            obj = getattr(module, name)
+            if isinstance(obj, type) and issubclass(obj, Strategy) and obj is not Strategy:
+                names.append(name)
+        config.STRATEGIES = names or config.STRATEGIES
+        system_logger.info("Auto selected strategies: %s", config.STRATEGIES)
+
+    def load_strategies(self):
+        """Dynamically load strategies from config."""
+        for pair in config.TRADING_PAIRS:
+            for name in config.STRATEGIES:
+                module = importlib.import_module("jasperboy.strategy")
+                cls = getattr(module, name)
+                strategy = cls(self.exchange, pair, config.TIMEFRAME)
+                strategy.weight = self.weights.get(name, 1.0)
+                self.strategies.append(strategy)
+        system_logger.info("Loaded strategies: %s", [s.__class__.__name__ for s in self.strategies])
+
+    def place_order(self, side: str, pair: str, amount: float) -> Any:
+        """Execute an order on the exchange or simulate it."""
+        if config.SIMULATE:
+            trade_logger.info("Simulated %s order for %s %s", side, amount, pair)
+            return {"simulated": True}
+        try:
+            if side == "buy":
+                return self.exchange.create_market_buy_order(pair, amount)
+            return self.exchange.create_market_sell_order(pair, amount)
+        except Exception as exc:
+            trade_logger.warning("Failed to place %s order: %s", side, exc)
+            return None
+
+    def check_system_health(self) -> None:
+        """Log basic system health metrics using psutil."""
+        cpu = psutil.cpu_percent()
+        mem = psutil.virtual_memory().percent
+        disk = psutil.disk_usage("/").percent
+        system_logger.debug(
+            "System health - CPU: %.1f%% MEM: %.1f%% DISK: %.1f%%",
+            cpu,
+            mem,
+            disk,
+        )
+
+    def evaluate(self):
+        """Evaluate strategies and manage positions for all pairs."""
+        self.check_system_health()
+        # Entry checks for each pair
+        for pair in config.TRADING_PAIRS:
+            try:
+                current_price = self.exchange.fetch_ticker(pair)["last"]
+            except Exception as exc:
+                system_logger.warning("Failed to fetch ticker for %s: %s", pair, exc)
+                continue
+
+            entry_votes = [s for s in self.strategies if s.pair == pair and s.should_enter()]
+            weight_sum = sum(getattr(s, "weight", 1.0) for s in entry_votes)
+            if weight_sum >= config.WEIGHT_THRESHOLD and len(self.positions) < config.MAX_POSITIONS:
+                if self.place_order("buy", pair, config.ORDER_SIZE):
+                    self.positions.append(
+                        Position(
+                            pair,
+                            current_price,
+                            config.ORDER_SIZE,
+                            "combined",
+                            highest_price=current_price,
+                            strategies=[s.__class__.__name__ for s in entry_votes],
+                        )
+                    )
+                    self.record_trade(pair, "enter", current_price, config.ORDER_SIZE, "combined")
+                    trade_logger.info("Entered %s with weight %.2f", pair, weight_sum)
+
+        # Exit checks for each open position
+        for pos in list(self.positions):
+            try:
+                current_price = self.exchange.fetch_ticker(pos.pair)["last"]
+            except Exception as exc:
+                system_logger.warning("Failed to fetch ticker for %s: %s", pos.pair, exc)
+                current_price = pos.entry_price
+
+            exit_votes = [s for s in self.strategies if s.pair == pos.pair and s.should_exit(pos)]
+            exit_weight = sum(getattr(s, "weight", 1.0) for s in exit_votes)
+            change_pct = (current_price - pos.entry_price) / pos.entry_price * 100
+            pos.highest_price = max(pos.highest_price, current_price)
+            risk_exit = False
+            if (
+                config.PARTIAL_TAKE_PROFIT_PCT
+                and not pos.partial_taken
+                and change_pct >= config.PARTIAL_TAKE_PROFIT_PCT
+            ):
+                close_amt = pos.amount * config.PARTIAL_TAKE_PROFIT_RATIO
+                if self.place_order("sell", pos.pair, close_amt):
+                    pnl = (current_price - pos.entry_price) * close_amt
+                    self.closed_profit += pnl
+                    pos.amount -= close_amt
+                    pos.partial_taken = True
+                    self.record_trade(pos.pair, "partial_exit", current_price, close_amt, "combined")
+                    trade_logger.info(
+                        "Partial take profit on %s for %.2f at %.2f%%",
+                        pos.pair,
+                        close_amt,
+                        change_pct,
+                    )
+
+            if config.TAKE_PROFIT_PCT and change_pct >= config.TAKE_PROFIT_PCT:
+                trade_logger.info("Take profit reached on %s: %.2f%%", pos.pair, change_pct)
+                risk_exit = True
+            elif config.STOP_LOSS_PCT and change_pct <= -config.STOP_LOSS_PCT:
+                trade_logger.info("Stop loss reached on %s: %.2f%%", pos.pair, change_pct)
+                risk_exit = True
+
+            if (
+                config.TRAILING_STOP_PCT
+                and pos.highest_price > 0
+                and current_price <= pos.highest_price * (1 - config.TRAILING_STOP_PCT / 100)
+            ):
+                trade_logger.info("Trailing stop triggered on %s", pos.pair)
+                risk_exit = True
+
+            if exit_weight >= config.WEIGHT_THRESHOLD or risk_exit:
+                if self.place_order("sell", pos.pair, pos.amount):
+                    pnl = (current_price - pos.entry_price) * pos.amount
+                    self.closed_profit += pnl
+                    trade_logger.info(
+                        "Exiting %s opened at %.2f with P/L %.2f", pos.pair, pos.entry_price, pnl
+                    )
+                    self.record_trade(pos.pair, "exit", current_price, pos.amount, "combined")
+                    self.adjust_weights(pos.strategies, pnl)
+                    self.positions.remove(pos)
+

--- a/jasperboy/config.py
+++ b/jasperboy/config.py
@@ -1,0 +1,103 @@
+import os
+
+# Basic configuration for the trading bot.
+# In a real setup, you would load these from environment variables
+# or a configuration file.
+
+# Exchange identifier and credentials.  These can be overridden
+# via environment variables or command-line arguments.
+EXCHANGE_ID = os.getenv("EXCHANGE_ID", "binance")
+EXCHANGE_API_KEY = os.getenv("EXCHANGE_API_KEY", "your-key")
+EXCHANGE_SECRET = os.getenv("EXCHANGE_SECRET", "your-secret")
+
+# Default trading pair and timeframe used when none are supplied by the user.
+TRADING_PAIR = os.getenv("TRADING_PAIR", "BTC/USDT")
+TIMEFRAME = os.getenv("TIMEFRAME", "1h")
+
+# Comma separated list of trading pairs.  When multiple pairs are provided
+# the bot will manage independent positions for each of them.
+_pairs_env = os.getenv("TRADING_PAIRS")
+if _pairs_env:
+    TRADING_PAIRS = [p.strip() for p in _pairs_env.split(",") if p.strip()]
+else:
+    TRADING_PAIRS = [TRADING_PAIR]
+
+# Automatically choose trading pairs if enabled. When AUTO_SELECT_PAIRS
+# is true, the bot will query the exchange for the most active markets
+# and trade the top AUTO_PAIR_COUNT pairs denominated in USDT.
+AUTO_SELECT_PAIRS = os.getenv("AUTO_SELECT_PAIRS", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+AUTO_PAIR_COUNT = int(os.getenv("AUTO_PAIR_COUNT", "3"))
+
+# List of strategy class names to load dynamically. The environment
+# variable STRATEGIES can override this with a comma separated list.
+_strategies_env = os.getenv("STRATEGIES")
+if _strategies_env:
+    STRATEGIES = [s.strip() for s in _strategies_env.split(",") if s.strip()]
+else:
+    STRATEGIES = [
+        "MovingAverageStrategy",
+        "RSIStrategy",
+        "BollingerBandStrategy",
+        "AdaptiveMovingAverageStrategy",
+    ]
+
+# When enabled, all available strategies are loaded automatically
+# regardless of the STRATEGIES variable. The bot can then decide
+# which ones to apply for each pair based on market data.
+AUTO_SELECT_STRATEGIES = os.getenv("AUTO_SELECT_STRATEGIES", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+# Path used to persist executed trades.  The bot will append to this
+# CSV file whenever a new position is opened or closed.
+DATA_PATH = os.getenv("DATA_PATH", "trades.csv")
+
+# Log verbosity and dashboard port.
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+DASHBOARD_PORT = int(os.getenv("DASHBOARD_PORT", "5000"))
+
+# Log file paths for trading activity and system events
+TRADING_LOG_PATH = os.getenv("TRADING_LOG_PATH", "trading.log")
+SYSTEM_LOG_PATH = os.getenv("SYSTEM_LOG_PATH", "system.log")
+
+# Evaluation interval in seconds for running the strategies.
+REFRESH_INTERVAL = int(os.getenv("REFRESH_INTERVAL", "60"))
+
+# Trade amount per order when entering or exiting positions.
+ORDER_SIZE = float(os.getenv("ORDER_SIZE", "1"))
+
+# Simulation mode skips actual order placement.
+SIMULATE = os.getenv("SIMULATE", "true").lower() in ("1", "true", "yes")
+
+# Threshold for how many strategies must agree before entering or exiting.
+ENTRY_THRESHOLD = int(os.getenv("ENTRY_THRESHOLD", "1"))
+EXIT_THRESHOLD = int(os.getenv("EXIT_THRESHOLD", "1"))
+
+# Risk management settings. Percentages are expressed as positive numbers.
+# Set to 0 to disable.
+STOP_LOSS_PCT = float(os.getenv("STOP_LOSS_PCT", "0"))
+TAKE_PROFIT_PCT = float(os.getenv("TAKE_PROFIT_PCT", "0"))
+
+# Maximum number of concurrent open positions
+MAX_POSITIONS = int(os.getenv("MAX_POSITIONS", "5"))
+
+# Partial take profit settings. When PARTIAL_TAKE_PROFIT_PCT is hit the
+# bot will close PARTIAL_TAKE_PROFIT_RATIO of the position.
+PARTIAL_TAKE_PROFIT_PCT = float(os.getenv("PARTIAL_TAKE_PROFIT_PCT", "0"))
+PARTIAL_TAKE_PROFIT_RATIO = float(os.getenv("PARTIAL_TAKE_PROFIT_RATIO", "0.5"))
+
+# Trailing stop percentage. Set to 0 to disable.
+TRAILING_STOP_PCT = float(os.getenv("TRAILING_STOP_PCT", "0"))
+
+# Path to persist strategy weights for the self-learning mechanism.
+WEIGHTS_PATH = os.getenv("WEIGHTS_PATH", "weights.json")
+
+# Minimum cumulative weight required to enter or exit a position.
+WEIGHT_THRESHOLD = float(os.getenv("WEIGHT_THRESHOLD", "1"))
+

--- a/jasperboy/dashboard.py
+++ b/jasperboy/dashboard.py
@@ -1,0 +1,116 @@
+from flask import Flask, render_template_string
+import base64
+from io import BytesIO
+import csv
+import os
+
+from . import config
+
+app = Flask(__name__)
+
+HTML = """
+<!doctype html>
+<html>
+<head>
+<title>Trading Bot Dashboard</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 4px; text-align: center; }
+th { background: #eee; }
+</style>
+</head>
+<body>
+<h1>Trading Bot Dashboard</h1>
+<p>Pairs: {{ pairs }} | Timeframe: {{ timeframe }} | Exchange: {{ exchange }} | Simulate: {{ simulate }}</p>
+<p>Refresh: {{ refresh }}s | Total Closed P/L: {{ total_pnl }}</p>
+<h2>Open Positions</h2>
+<table>
+    <tr><th>Pair</th><th>Strategy</th><th>Entry Price</th><th>Amount</th><th>P/L</th><th>P/L %</th></tr>
+    {% for p in positions %}
+    <tr><td>{{ p.pair }}</td><td>{{ p.strategy }}</td><td>{{ p.entry_price }}</td><td>{{ p.amount }}</td><td>{{ p.pnl }}</td><td>{{ p.pnl_pct }}</td></tr>
+    {% endfor %}
+</table>
+<p><a href="/trades">Trade history</a></p>
+<img src="data:image/png;base64,{{ chart }}" alt="P/L chart" />
+</body>
+</html>
+"""
+
+def create_app(bot):
+    @app.route("/")
+    def index():
+        positions = []
+        for p in bot.positions:
+            current = bot.exchange.fetch_ticker(p.pair)["last"]
+            pnl = (current - p.entry_price) * p.amount
+            pct = pnl / (p.entry_price * p.amount) * 100 if p.amount else 0
+            positions.append({
+                "pair": p.pair,
+                "strategy": p.strategy,
+                "entry_price": p.entry_price,
+                "amount": p.amount,
+                "pnl": round(pnl, 2),
+                "pnl_pct": round(pct, 2),
+            })
+        chart = generate_pnl_chart(bot.data_path)
+        return render_template_string(
+            HTML,
+            positions=positions,
+            pairs=", ".join(config.TRADING_PAIRS),
+            timeframe=config.TIMEFRAME,
+            exchange=config.EXCHANGE_ID,
+            simulate=config.SIMULATE,
+            refresh=config.REFRESH_INTERVAL,
+            total_pnl=round(bot.closed_profit, 2),
+            chart=chart,
+        )
+
+    @app.route("/trades")
+    def trades():
+        if not bot.data_path or not os.path.exists(bot.data_path):
+            rows = []
+        else:
+            with open(bot.data_path) as f:
+                rows = list(csv.reader(f))[1:][-20:]
+        history_html = """
+        <h1>Recent Trades</h1>
+        <table border='1'>
+            <tr><th>Timestamp</th><th>Pair</th><th>Action</th><th>Price</th><th>Amount</th><th>Strategy</th></tr>
+            {% for r in rows %}
+            <tr>{% for c in r %}<td>{{ c }}</td>{% endfor %}</tr>
+            {% endfor %}
+        </table>
+        <p><a href='/'>Back</a></p>
+        """
+        return render_template_string(history_html, rows=rows)
+
+    def generate_pnl_chart(csv_path):
+        if not csv_path or not os.path.exists(csv_path):
+            return ""
+        with open(csv_path) as f:
+            rows = list(csv.reader(f))[1:]
+        pnl = 0
+        entries = {}
+        curve = []
+        for ts, pair, action, price, amount, _ in rows:
+            price = float(price)
+            amount = float(amount)
+            if action == "enter":
+                entries.setdefault(pair, []).append((price, amount))
+            else:
+                entry_price, amt = entries.get(pair, [(price, amount)]).pop(0)
+                pnl += (price - entry_price) * amt
+            curve.append(pnl)
+        if not curve:
+            return ""
+        import matplotlib.pyplot as plt
+        fig, ax = plt.subplots()
+        ax.plot(curve)
+        ax.set_title("Cumulative P/L")
+        buf = BytesIO()
+        fig.savefig(buf, format="png")
+        plt.close(fig)
+        return base64.b64encode(buf.getvalue()).decode()
+
+    return app

--- a/jasperboy/run_bot.py
+++ b/jasperboy/run_bot.py
@@ -1,0 +1,114 @@
+"""Entry point for running the trading bot with dashboard."""
+import argparse
+import threading
+import time
+
+from .bot import TradingBot
+from .dashboard import create_app
+from . import config
+
+
+def run_bot(bot: TradingBot):
+    """Continuously evaluate strategies using the configured interval."""
+    while True:
+        bot.evaluate()
+        time.sleep(config.REFRESH_INTERVAL)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run the trading bot")
+    parser.add_argument("--pair", default=config.TRADING_PAIR, help="Primary trading pair, e.g. BTC/USDT")
+    parser.add_argument("--pairs", default=','.join(config.TRADING_PAIRS), help="Comma-separated list of trading pairs")
+    parser.add_argument("--auto-pairs", action="store_true", default=config.AUTO_SELECT_PAIRS, help="Select trading pairs automatically")
+    parser.add_argument("--auto-pair-count", type=int, default=config.AUTO_PAIR_COUNT, help="Number of pairs to auto select")
+    parser.add_argument("--timeframe", default=config.TIMEFRAME, help="OHLCV timeframe")
+    parser.add_argument("--exchange", default=config.EXCHANGE_ID, help="Exchange id from ccxt")
+    parser.add_argument("--port", type=int, default=config.DASHBOARD_PORT, help="Dashboard port")
+    parser.add_argument("--order-size", type=float, default=config.ORDER_SIZE, help="Amount to trade")
+    parser.add_argument("--simulate", action="store_true", default=config.SIMULATE, help="Run without placing real orders")
+    parser.add_argument("--refresh-interval", type=int, default=config.REFRESH_INTERVAL, help="Seconds between evaluations")
+    parser.add_argument("--data-path", default=config.DATA_PATH, help="CSV file to persist trades")
+    parser.add_argument("--entry-threshold", type=int, default=config.ENTRY_THRESHOLD, help="Number of strategies required to enter")
+    parser.add_argument("--exit-threshold", type=int, default=config.EXIT_THRESHOLD, help="Number of strategies required to exit")
+    parser.add_argument(
+        "--strategies",
+        default=','.join(config.STRATEGIES),
+        help="Comma-separated list of strategy class names",
+    )
+    parser.add_argument("--auto-strategies", action="store_true", default=config.AUTO_SELECT_STRATEGIES, help="Load all strategies automatically")
+    parser.add_argument(
+        "--stop-loss",
+        type=float,
+        default=config.STOP_LOSS_PCT,
+        help="Stop loss percentage",
+    )
+    parser.add_argument(
+        "--take-profit",
+        type=float,
+        default=config.TAKE_PROFIT_PCT,
+        help="Take profit percentage",
+    )
+    parser.add_argument(
+        "--max-positions",
+        type=int,
+        default=config.MAX_POSITIONS,
+        help="Maximum number of open positions",
+    )
+    parser.add_argument(
+        "--partial-tp",
+        type=float,
+        default=config.PARTIAL_TAKE_PROFIT_PCT,
+        help="Partial take profit percentage",
+    )
+    parser.add_argument(
+        "--partial-ratio",
+        type=float,
+        default=config.PARTIAL_TAKE_PROFIT_RATIO,
+        help="Fraction to close when partial take profit triggers",
+    )
+    parser.add_argument(
+        "--trailing-stop",
+        type=float,
+        default=config.TRAILING_STOP_PCT,
+        help="Trailing stop percentage",
+    )
+    parser.add_argument(
+        "--weight-threshold",
+        type=float,
+        default=config.WEIGHT_THRESHOLD,
+        help="Minimum combined strategy weight before a trade",
+    )
+    args = parser.parse_args(argv)
+
+    # Update configuration based on CLI args
+    config.TRADING_PAIR = args.pair
+    config.TRADING_PAIRS = [p.strip() for p in args.pairs.split(',') if p.strip()]
+    config.AUTO_SELECT_PAIRS = args.auto_pairs
+    config.AUTO_PAIR_COUNT = args.auto_pair_count
+    config.TIMEFRAME = args.timeframe
+    config.EXCHANGE_ID = args.exchange
+    config.DASHBOARD_PORT = args.port
+    config.ORDER_SIZE = args.order_size
+    config.SIMULATE = args.simulate
+    config.REFRESH_INTERVAL = args.refresh_interval
+    config.DATA_PATH = args.data_path
+    config.ENTRY_THRESHOLD = args.entry_threshold
+    config.EXIT_THRESHOLD = args.exit_threshold
+    config.STRATEGIES = [s.strip() for s in args.strategies.split(',') if s.strip()]
+    config.AUTO_SELECT_STRATEGIES = args.auto_strategies
+    config.STOP_LOSS_PCT = args.stop_loss
+    config.TAKE_PROFIT_PCT = args.take_profit
+    config.MAX_POSITIONS = args.max_positions
+    config.PARTIAL_TAKE_PROFIT_PCT = args.partial_tp
+    config.PARTIAL_TAKE_PROFIT_RATIO = args.partial_ratio
+    config.TRAILING_STOP_PCT = args.trailing_stop
+    config.WEIGHT_THRESHOLD = args.weight_threshold
+
+    bot = TradingBot(exchange_id=args.exchange)
+    app = create_app(bot)
+    threading.Thread(target=run_bot, args=(bot,), daemon=True).start()
+    app.run(port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/jasperboy/strategy.py
+++ b/jasperboy/strategy.py
@@ -1,0 +1,134 @@
+import abc
+import logging
+from typing import Any
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+class Strategy(abc.ABC):
+    """Abstract base class for trading strategies."""
+
+    weight: float = 1.0
+
+    def __init__(self, exchange, pair: str, timeframe: str):
+        self.exchange = exchange
+        self.pair = pair
+        self.timeframe = timeframe
+        self.data = pd.DataFrame()
+
+    def update_data(self):
+        """Fetch recent OHLCV data from the exchange."""
+        try:
+            ohlcv = self.exchange.fetch_ohlcv(self.pair, timeframe=self.timeframe)
+        except Exception as exc:
+            logger.warning("Failed to fetch OHLCV data: %s", exc)
+            return
+        self.data = pd.DataFrame(
+            ohlcv,
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
+        )
+
+    @abc.abstractmethod
+    def should_enter(self) -> bool:
+        """Return True if a position should be opened."""
+
+    @abc.abstractmethod
+    def should_exit(self, position: Any) -> bool:
+        """Return True if a position should be closed."""
+
+class MovingAverageStrategy(Strategy):
+    """Simple moving average crossover strategy."""
+
+    short_window = 7
+    long_window = 25
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        if len(self.data) < self.long_window:
+            return False
+        short_ma = self.data["close"].rolling(self.short_window).mean().iloc[-1]
+        long_ma = self.data["close"].rolling(self.long_window).mean().iloc[-1]
+        return short_ma > long_ma
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        short_ma = self.data["close"].rolling(self.short_window).mean().iloc[-1]
+        long_ma = self.data["close"].rolling(self.long_window).mean().iloc[-1]
+        return short_ma < long_ma
+
+class RSIStrategy(Strategy):
+    """Relative Strength Index strategy."""
+
+    rsi_period = 14
+    overbought = 70
+    oversold = 30
+
+    def _rsi(self) -> float:
+        delta = self.data["close"].diff()
+        up = delta.clip(lower=0).ewm(alpha=1 / self.rsi_period).mean()
+        down = -delta.clip(upper=0).ewm(alpha=1 / self.rsi_period).mean()
+        rs = up / down
+        return 100 - (100 / (1 + rs)).iloc[-1]
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        if len(self.data) < self.rsi_period:
+            return False
+        return self._rsi() < self.oversold
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        if len(self.data) < self.rsi_period:
+            return False
+        return self._rsi() > self.overbought
+
+
+class BollingerBandStrategy(Strategy):
+    """Bollinger Bands mean reversion strategy."""
+
+    window = 20
+    num_std = 2
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        if len(self.data) < self.window:
+            return False
+        ma = self.data["close"].rolling(self.window).mean().iloc[-1]
+        std = self.data["close"].rolling(self.window).std().iloc[-1]
+        lower = ma - self.num_std * std
+        price = self.data["close"].iloc[-1]
+        return price < lower
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        if len(self.data) < self.window:
+            return False
+        ma = self.data["close"].rolling(self.window).mean().iloc[-1]
+        price = self.data["close"].iloc[-1]
+        return price > ma
+
+
+class AdaptiveMovingAverageStrategy(MovingAverageStrategy):
+    """Moving average crossover with auto-adjusted windows."""
+
+    def update_windows(self):
+        """Adjust windows based on historical volatility."""
+        closes = self.data["close"]
+        if len(closes) < 50:
+            return
+        vol = closes.pct_change().rolling(50).std().iloc[-1]
+        factor = max(1, min(5, round(vol * 100)))
+        self.short_window = 5 * factor
+        self.long_window = 20 * factor
+
+    def should_enter(self) -> bool:
+        self.update_data()
+        self.update_windows()
+        return super().should_enter()
+
+    def should_exit(self, position: Any) -> bool:
+        self.update_data()
+        self.update_windows()
+        return super().should_exit(position)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+ccxt
+flask
+pandas
+matplotlib
+psutil


### PR DESCRIPTION
## Summary
- add WEIGHTS_PATH and WEIGHT_THRESHOLD settings
- maintain per-strategy weights that update on trade profit/loss
- use weighted voting for entries and exits
- expose `--weight-threshold` CLI option and document adaptive weighting

## Testing
- `python -m py_compile jasperboy/*.py`
- `python -m jasperboy.run_bot --help | head -n 20`
- `python -m jasperboy.run_bot --help | tail -n 20`
- `python -m jasperboy.backtest --help | head -n 20`
- `python -m jasperboy.backtest --help | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68814107947083239e1ca58c399258f0